### PR TITLE
Remove eclipse release dependencies from Android/App engine 

### DIFF
--- a/NCWITMOBILEAPP-Android/.classpath
+++ b/NCWITMOBILEAPP-Android/.classpath
@@ -13,6 +13,6 @@
 	<classpathentry exported="true" kind="con" path="com.android.ide.eclipse.adt.ANDROID_FRAMEWORK"/>
 	<classpathentry kind="con" path="com.android.ide.eclipse.adt.LIBRARIES"/>
 	<classpathentry kind="lib" path="lib/requestfactory-client.jar"/>
-	<classpathentry kind="lib" path="C:/Program Files/Eclipse/eclipse.3.7.2/plugins/com.google.gwt.eclipse.sdkbundle_2.4.0.v201203300216-rel-r37/gwt-2.4.0/gwt-user.jar"/>
+	<classpathentry kind="var" path="ECLIPSE_HOME/plugins/com.google.gwt.eclipse.sdkbundle_2.4.0.v201203300216-rel-r37/gwt-2.4.0/gwt-user.jar"/>
 	<classpathentry kind="output" path="bin/classes"/>
 </classpath>

--- a/NCWITMOBILEAPP-Android/.factorypath
+++ b/NCWITMOBILEAPP-Android/.factorypath
@@ -1,3 +1,4 @@
 <factorypath>
-    <factorypathentry kind="EXTJAR" id="C:\Program Files\Eclipse\Eclipse-3.7.1.classic\plugins\com.google.gwt.eclipse.sdkbundle_2.4.0.v201203300216-rel-r37\gwt-2.4.0\requestfactory-apt.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="ECLIPSE_HOME/plugins/com.google.gwt.eclipse.sdkbundle_2.4.0.v201203300216-rel-r37/gwt-2.4.0/gwt-user.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="ECLIPSE_HOME/plugins/com.google.gwt.eclipse.sdkbundle_2.4.0.v201203300216-rel-r37/gwt-2.4.0/requestfactory-apt.jar" enabled="true" runInBatchMode="false"/>
 </factorypath>

--- a/NCWITMOBILEAPP-AppEngine/.factorypath
+++ b/NCWITMOBILEAPP-AppEngine/.factorypath
@@ -1,3 +1,3 @@
 <factorypath>
-    <factorypathentry kind="EXTJAR" id="C:\Program Files\Eclipse\Eclipse-3.7.1.classic\plugins\com.google.gwt.eclipse.sdkbundle_2.4.0.v201203300216-rel-r37\gwt-2.4.0\requestfactory-apt.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="ECLIPSE_HOME/plugins/com.google.gwt.eclipse.sdkbundle_2.4.0.v201203300216-rel-r37/gwt-2.4.0/requestfactory-apt.jar" enabled="true" runInBatchMode="false"/>
 </factorypath>


### PR DESCRIPTION
Removed Eclipse release form factory path and classpath.  
These are now built off ECLIPSE_HOME
